### PR TITLE
Add standard appearance property for number input

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -230,6 +230,7 @@ body {
 
 .amount-input[type="number"] {
   -moz-appearance: textfield;
+  appearance: textfield;
 }
 
 


### PR DESCRIPTION
## Summary
- add the standard `appearance: textfield` declaration to number inputs to complement vendor-specific overrides

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de3a33b7208331a7b20a8432ef7c38